### PR TITLE
Move lifecycle listener to room connection events

### DIFF
--- a/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
+++ b/android/src/main/java/com/twiliorn/library/CustomTwilioVideoView.java
@@ -149,9 +149,6 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
     this.themedReactContext = context;
     this.eventEmitter = themedReactContext.getJSModule(RCTEventEmitter.class);
 
-    // add lifecycle for onResume and on onPause
-    themedReactContext.addLifecycleEventListener(this);
-
     /*
      * Enable changing the volume using the up/down keys during a conversation
      */
@@ -567,6 +564,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         }
         event.putArray("participants", participantsArray);
 
+        // add lifecycle for onResume and on onPause
+        themedReactContext.addLifecycleEventListener(CustomTwilioVideoView.this);
+
         pushEvent(CustomTwilioVideoView.this, ON_CONNECTED, event);
 
         for (RemoteParticipant participant : participants) {
@@ -604,6 +604,9 @@ public class CustomTwilioVideoView extends View implements LifecycleEventListene
         if (!disconnectedFromOnDestroy) {
           setAudioFocus(false);
         }
+
+        // now that the room is disconnected, stop listening for lifecycle events
+        themedReactContext.removeLifecycleEventListener(CustomTwilioVideoView.this);
 
         // finally fire the disconnect event
         pushEvent(CustomTwilioVideoView.this, ON_DISCONNECTED, event);


### PR DESCRIPTION
## Ticket

https://reliantid.atlassian.net/browse/MDBOX-2749

## What this does

Moves the lifecycle listeners to the room connection events, instead of the constructor.  This should prevent the lifecycle events from unexpectedly closing the video, when the video is being connected on the second video connection.

## Why we did this

Android crashing issues.

## Testing Performed

Samsung S7
Samsung S8

## Overall, I feel this way about this code

Ok